### PR TITLE
chore: remove pkg/errors dependency + lint fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Gurpartap/storekit-go
 
-go 1.14
-
-require github.com/pkg/errors v0.9.1
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/receipt_response.go
+++ b/receipt_response.go
@@ -10,7 +10,7 @@ package storekit
 type ReceiptResponseStatus int
 
 const (
-	// Undocumented but occurs
+	// Undocumented but occurs.
 	ReceiptResponseStatusUnknown ReceiptResponseStatus = -1
 
 	// Receipt is valid.


### PR DESCRIPTION
This PR removes the `pkg/errors` package dependency because since Go v1.13, the same can be done with `fmt`: https://go.dev/blog/go1.13-errors

Also, I updated the Go version to 1.16 to switch from deprecated `ioutil.ReadAll` to `io.ReadAll`:
https://go.dev/doc/go1.16#ioutil

Plus, a few minor lint fixes.